### PR TITLE
feat: refactor embed scripts

### DIFF
--- a/Table/package.json
+++ b/Table/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "deploy": "npm run build && cd dist && gcloud storage cp -r * gs://projects.twreporter.org/twreporter/ddd/2025-0911-lawmaker-electricity/table/",
+    "deploy": "npm run build && cd dist && gcloud storage cp assets/* gs://projects.twreporter.org/twreporter/ddd/2025-0911-lawmaker-electricity/table/assets && gcloud storage cp *.html gs://projects.twreporter.org/twreporter/ddd/2025-0911-lawmaker-electricity/table --cache-control='public, max-age=300'",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig tsconfig.app.json && tsc -p tsconfig.node.json"
   },

--- a/WordCloud/package.json
+++ b/WordCloud/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "deploy": "npm run build && cd dist && gcloud storage cp -r * gs://projects.twreporter.org/twreporter/ddd/2025-0911-lawmaker-electricity/word-cloud/",
+    "deploy": "npm run build && cd dist && gcloud storage cp assets/* gs://projects.twreporter.org/twreporter/ddd/2025-0911-lawmaker-electricity/word-cloud/assets && gcloud storage cp *.html gs://projects.twreporter.org/twreporter/ddd/2025-0911-lawmaker-electricity/word-cloud --cache-control='public, max-age=300'",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig tsconfig.app.json && tsc -p tsconfig.node.json"
   },

--- a/embed.css
+++ b/embed.css
@@ -1,0 +1,5 @@
+iframe[id^='twreporter'] {
+  border: none;
+  width: 100%;
+  overflow: hidden;
+}

--- a/embed.js
+++ b/embed.js
@@ -1,0 +1,17 @@
+window.addEventListener('message', (event) => {
+  if (
+    event.origin !== 'https://projects.twreporter.org' &&
+    !event.origin.startsWith('http://localhost')
+  )
+    return
+
+  const sourceId = event.data.source
+
+  console.log(event.data)
+
+  const iframe = document.getElementById(sourceId)
+
+  if (!iframe || !event.data.bodyHeight) return
+
+  iframe.style.height = event.data.bodyHeight + 'px'
+})

--- a/embed.js
+++ b/embed.js
@@ -7,8 +7,6 @@ window.addEventListener('message', (event) => {
 
   const sourceId = event.data.source
 
-  console.log(event.data)
-
   const iframe = document.getElementById(sourceId)
 
   if (!iframe || !event.data.bodyHeight) return

--- a/index.html
+++ b/index.html
@@ -1,76 +1,47 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Title</title>
-  <style>
-    .export { width: 730px; }
-  </style>
-</head>
-<body style="background-color: #f1f1f1;">
-<div class="export">
-  <iframe src="http://localhost:5173/twreporter/ddd/2025-0911-lawmaker-electricity/table/index.html?term=10"
-          style="border: none; width: 100%; overflow: clip;" id="twreporter-table-10"></iframe>
-  <script>
-      const tableId = 'twreporter-table-10';
-      const tableIframe = document.getElementById(tableId);
-      tableIframe.style.height = '500px';
-      window.addEventListener("message", (e) => {
-
-          if (e.data.source !== tableId) return;
-
-          tableIframe.style.height = e.data.bodyHeight + 'px';
-      });
-  </script>
-</div>
-xxx
-<div class="export">
-  <iframe src="http://localhost:5173/twreporter/ddd/2025-0911-lawmaker-electricity/table/index.html?term=11"
-          style="border: none; width: 100%; overflow: clip;" id="twreporter-table-11"></iframe>
-  <script>
-      const tableId = 'twreporter-table-11';
-      const tableIframe = document.getElementById(tableId);
-      tableIframe.style.height = '500px';
-      window.addEventListener("message", (e) => {
-
-          if (e.data.source !== tableId) return;
-
-          tableIframe.style.height = e.data.bodyHeight + 'px';
-      });
-  </script>
-</div>
-xxx<br>
-xxx
-<div class="export">
-  <iframe src="http://localhost:5174/twreporter/ddd/2025-0911-lawmaker-electricity/word-cloud/index.html?party=all"
-          style="border: none; width: 100%; overflow: clip;" id="twreporter-wordcloud-all"></iframe>
-  <script>
-      const wordCloudId = 'twreporter-wordcloud-all';
-      const wordCloudIframe = document.getElementById(wordCloudId);
-      wordCloudIframe.style.height = '500px';
-      window.addEventListener("message", (e) => {
-
-          if (e.data.source !== wordCloudId) return;
-
-          wordCloudIframe.style.height = e.data.bodyHeight + 'px';
-      });
-  </script>
-</div>
-xxx
-<div class="export">
-  <iframe src="http://localhost:5174/twreporter/ddd/2025-0911-lawmaker-electricity/word-cloud/index.html?party=tpp"
-          style="border: none; width: 100%; overflow: clip;" id="twreporter-wordcloud-tpp"></iframe>
-  <script>
-      const wordCloudId = 'twreporter-wordcloud-tpp';
-      const wordCloudIframe = document.getElementById(wordCloudId);
-      wordCloudIframe.style.height = '500px';
-      window.addEventListener("message", (e) => {
-
-          if (e.data.source !== wordCloudId) return;
-
-          wordCloudIframe.style.height = e.data.bodyHeight + 'px';
-      });
-  </script>
-</div>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Title</title>
+    <style>
+      .export {
+        max-width: 730px;
+      }
+    </style>
+  </head>
+  <body style="background-color: #f1f1f1">
+    <div class="export">
+      <iframe
+        src="http://localhost:5173/twreporter/ddd/2025-0911-lawmaker-electricity/table/index.html?term=10"
+        style="border: none; width: 100%; overflow: clip"
+        id="twreporter-table-10"
+      ></iframe>
+    </div>
+    xxx
+    <div class="export">
+      <iframe
+        src="http://localhost:5173/twreporter/ddd/2025-0911-lawmaker-electricity/table/index.html?term=11"
+        style="border: none; width: 100%; overflow: clip"
+        id="twreporter-table-11"
+      ></iframe>
+    </div>
+    xxx<br />
+    xxx
+    <div class="export">
+      <iframe
+        src="http://localhost:5174/twreporter/ddd/2025-0911-lawmaker-electricity/word-cloud/index.html?party=all"
+        style="border: none; width: 100%; overflow: clip"
+        id="twreporter-wordcloud-all"
+      ></iframe>
+    </div>
+    xxx
+    <div class="export">
+      <iframe
+        src="http://localhost:5174/twreporter/ddd/2025-0911-lawmaker-electricity/word-cloud/index.html?party=tpp"
+        style="border: none; width: 100%; overflow: clip"
+        id="twreporter-wordcloud-tpp"
+      ></iframe>
+    </div>
+    <script src="embed.js"></script>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
     <div class="export">
       <iframe
         src="http://localhost:5173/twreporter/ddd/2025-0911-lawmaker-electricity/table/index.html?term=10"
-        style="border: none; width: 100%; overflow: clip"
         id="twreporter-table-10"
       ></iframe>
     </div>
@@ -21,7 +20,6 @@
     <div class="export">
       <iframe
         src="http://localhost:5173/twreporter/ddd/2025-0911-lawmaker-electricity/table/index.html?term=11"
-        style="border: none; width: 100%; overflow: clip"
         id="twreporter-table-11"
       ></iframe>
     </div>
@@ -30,7 +28,6 @@
     <div class="export">
       <iframe
         src="http://localhost:5174/twreporter/ddd/2025-0911-lawmaker-electricity/word-cloud/index.html?party=all"
-        style="border: none; width: 100%; overflow: clip"
         id="twreporter-wordcloud-all"
       ></iframe>
     </div>
@@ -38,10 +35,10 @@
     <div class="export">
       <iframe
         src="http://localhost:5174/twreporter/ddd/2025-0911-lawmaker-electricity/word-cloud/index.html?party=tpp"
-        style="border: none; width: 100%; overflow: clip"
         id="twreporter-wordcloud-tpp"
       ></iframe>
     </div>
+    <link rel="stylesheet" href="embed.css" />
     <script src="embed.js"></script>
   </body>
 </html>

--- a/index.prod.html
+++ b/index.prod.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Title</title>
+    <style>
+      .export {
+        max-width: 730px;
+      }
+    </style>
+  </head>
+  <body style="background-color: #f1f1f1">
+    <div class="export">
+      <iframe
+        src="https://projects.twreporter.org/twreporter/ddd/2025-0911-lawmaker-electricity/table/index.html?term=10&1"
+        id="twreporter-table-10"
+      ></iframe>
+    </div>
+    xxx
+    <div class="export">
+      <iframe
+        src="https://projects.twreporter.org/twreporter/ddd/2025-0911-lawmaker-electricity/table/index.html?term=11&1"
+        id="twreporter-table-11"
+      ></iframe>
+    </div>
+    xxx<br />
+    xxx
+    <div class="export">
+      <iframe
+        src="https://projects.twreporter.org/twreporter/ddd/2025-0911-lawmaker-electricity/word-cloud/index.html?party=all&1"
+        id="twreporter-wordcloud-all"
+      ></iframe>
+    </div>
+    xxx
+    <div class="export">
+      <iframe
+        src="https://projects.twreporter.org/twreporter/ddd/2025-0911-lawmaker-electricity/word-cloud/index.html?party=tpp&1"
+        id="twreporter-wordcloud-tpp"
+      ></iframe>
+    </div>
+    <link
+      rel="stylesheet"
+      href="https://projects.twreporter.org/twreporter/ddd/2025-0911-lawmaker-electricity/embed.css"
+    />
+    <script src="https://projects.twreporter.org/twreporter/ddd/2025-0911-lawmaker-electricity/embed.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
原本的 embed script 遇到多個元件的時候，會用到同一個變數名，導致第二個變數定義失敗，沒有辦法綁到 `EventListener`，所以調整以下：

- 把所有元件的 embed script 整合變成同一個檔案，並根據 iframe 內 `postMessage` 回傳的`source` 作為 id 動態選擇元件
  - 同時加入 origin 檢查
- 整合 embed script 的 css
- 更新 `npm run deploy` script 讓 html 快取時間降低


